### PR TITLE
Creating database api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .*cache
+*__pycache__

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,6 +28,17 @@ test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytes
 trio = ["trio (>=0.16)"]
 
 [[package]]
+name = "asgiref"
+version = "3.5.0"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+
+[[package]]
 name = "asn1crypto"
 version = "1.4.0"
 description = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
@@ -91,7 +102,7 @@ python-versions = ">=3.6.1"
 name = "click"
 version = "8.0.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -102,7 +113,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -154,6 +165,14 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
 docs = ["sphinx"]
+
+[[package]]
+name = "h11"
+version = "0.13.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "identify"
@@ -371,7 +390,7 @@ asn1crypto = ">=1.4.0"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -414,6 +433,32 @@ postgresql_psycopg2binary = ["psycopg2-binary"]
 postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
+
+[[package]]
+name = "sqlalchemy-utils"
+version = "0.38.2"
+description = "Various utility functions for SQLAlchemy."
+category = "main"
+optional = false
+python-versions = "~=3.4"
+
+[package.dependencies]
+six = "*"
+SQLAlchemy = ">=1.0"
+
+[package.extras]
+arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
+encrypted = ["cryptography (>=0.6)"]
+intervals = ["intervals (>=0.7.1)"]
+password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "backports.zoneinfo"]
+test_all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "arrow (>=0.3.4)", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "mock (==2.0.0)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)", "backports.zoneinfo"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
 
 [[package]]
 name = "starlette"
@@ -480,6 +525,22 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "uvicorn"
+version = "0.17.4"
+description = "The lightning-fast ASGI server."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+asgiref = ">=3.4.0"
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["websockets (>=10.0)", "httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
+
+[[package]]
 name = "virtualenv"
 version = "20.13.1"
 description = "Virtual Python Environment builder"
@@ -508,7 +569,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8ba9ad847aa86de1efa2246b473522d2e02e9231ca4eb3f7277d514541f730ba"
+content-hash = "faf00390b615fd7e2740ef93339bce9258bf001abcfb6663daaf956aab72e76a"
 
 [metadata.files]
 alchemy-mock = [
@@ -518,6 +579,10 @@ alchemy-mock = [
 anyio = [
     {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
     {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
+]
+asgiref = [
+    {file = "asgiref-3.5.0-py3-none-any.whl", hash = "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"},
+    {file = "asgiref-3.5.0.tar.gz", hash = "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0"},
 ]
 asn1crypto = [
     {file = "asn1crypto-1.4.0-py2.py3-none-any.whl", hash = "sha256:4bcdf33c861c7d40bdcd74d8e4dd7661aac320fcdf40b9a3f95b4ee12fde2fa8"},
@@ -636,6 +701,10 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
+]
+h11 = [
+    {file = "h11-0.13.0-py3-none-any.whl", hash = "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"},
+    {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
 ]
 identify = [
     {file = "identify-2.4.9-py2.py3-none-any.whl", hash = "sha256:bff7c4959d68510bc28b99d664b6a623e36c6eadc933f89a4e0a9ddff9b4fee4"},
@@ -895,6 +964,10 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.31-cp39-cp39-win_amd64.whl", hash = "sha256:9e4fb2895b83993831ba2401b6404de953fdbfa9d7d4fa6a4756294a83bbc94f"},
     {file = "SQLAlchemy-1.4.31.tar.gz", hash = "sha256:582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418"},
 ]
+sqlalchemy-utils = [
+    {file = "SQLAlchemy-Utils-0.38.2.tar.gz", hash = "sha256:9e01d6d3fb52d3926fcd4ea4a13f3540701b751aced0316bff78264402c2ceb4"},
+    {file = "SQLAlchemy_Utils-0.38.2-py3-none-any.whl", hash = "sha256:622235b1598f97300e4d08820ab024f5219c9a6309937a8b908093f487b4ba54"},
+]
 starlette = [
     {file = "starlette-0.17.1-py3-none-any.whl", hash = "sha256:26a18cbda5e6b651c964c12c88b36d9898481cd428ed6e063f5f29c418f73050"},
     {file = "starlette-0.17.1.tar.gz", hash = "sha256:57eab3cc975a28af62f6faec94d355a410634940f10b30d68d31cb5ec1b44ae8"},
@@ -918,6 +991,10 @@ tomli = [
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+]
+uvicorn = [
+    {file = "uvicorn-0.17.4-py3-none-any.whl", hash = "sha256:e85872d84fb651cccc4c5d2a71cf7ead055b8fb4d8f1e78e36092282c0cf2aec"},
+    {file = "uvicorn-0.17.4.tar.gz", hash = "sha256:25850bbc86195a71a6477b3e4b3b7b4c861fb687fb96912972ce5324472b1011"},
 ]
 virtualenv = [
     {file = "virtualenv-20.13.1-py2.py3-none-any.whl", hash = "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,16 @@
 [[package]]
+name = "alchemy-mock"
+version = "0.4.3"
+description = "SQLAlchemy mock helpers."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+sqlalchemy = "*"
+
+[[package]]
 name = "anyio"
 version = "3.5.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -496,9 +508,13 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "48245be350d2f26857ef89df8d6a40c87adebc404ff608789c886614a6d50933"
+content-hash = "8ba9ad847aa86de1efa2246b473522d2e02e9231ca4eb3f7277d514541f730ba"
 
 [metadata.files]
+alchemy-mock = [
+    {file = "alchemy-mock-0.4.3.tar.gz", hash = "sha256:7914c3f56aa7dd793d31a5ea3816972ff57de6e3c82651febfaab135e8f39d7a"},
+    {file = "alchemy_mock-0.4.3-py2.py3-none-any.whl", hash = "sha256:e076b11cdef76638f4de70d50f0d8cb851d69c41346d984371f757c8fb4a0efa"},
+]
 anyio = [
     {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
     {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pre-commit = "^2.17.0"
 black = "^22.1.0"
 mypy = "^0.931"
 "testing.postgresql" = "^1.3.0"
+alchemy-mock = "^0.4.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ SQLAlchemy = "^1.4.31"
 pydantic = "^1.9.0"
 psycopg2-binary = "^2.9.3"
 fastapi = "^0.73.0"
+uvicorn = "^0.17.4"
+SQLAlchemy-Utils = "^0.38.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/skate_tricks/api_endpoints.py
+++ b/skate_tricks/api_endpoints.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI, Depends
+from pydantic import typing
+from sqlalchemy.orm import Session
+
+from skate_tricks.configs.db_config import get_db_session
+from skate_tricks.schemas import pydantic_schemas as json_schemas
+from skate_tricks.schemas import postgres_models as models
+from skate_tricks import database_operations as db_op
+
+app = FastAPI()
+
+
+@app.get("/")
+async def home() -> typing.Dict:
+    return {"Home": "A Skateboarding tricks database"}
+
+
+@app.get("/trick-book/all/", response_model=typing.List[json_schemas.SkateTricks])
+async def get_all_tricks(
+    db: Session = Depends(get_db_session),
+) -> typing.List[models.SkateTricks]:
+    trick_book = db_op.get_all_tricks(db=db)
+    return trick_book
+
+
+@app.post("/trick-book/", response_model=json_schemas.SkateTricksBase)
+async def post_new_trick(
+    trick: json_schemas.SkateTricksBase, db: Session = Depends(get_db_session)
+) -> models.SkateTricks:
+    new_trick = db_op.post_new_trick(trick=trick, db=db)
+    return new_trick

--- a/skate_tricks/configs/api_config.py
+++ b/skate_tricks/configs/api_config.py
@@ -1,0 +1,10 @@
+from pydantic import BaseSettings
+
+
+class ApiSettings(BaseSettings):
+    API_PORT: int
+    API_SPEC_ROUTE: str
+
+
+def get_api_settings() -> ApiSettings:
+    return ApiSettings()

--- a/skate_tricks/configs/db_config.py
+++ b/skate_tricks/configs/db_config.py
@@ -3,7 +3,11 @@ from psycopg2.extras import DictCursor
 from pydantic import BaseSettings, PostgresDsn, validator, typing
 from fastapi import Depends
 from sqlalchemy import create_engine
+from sqlalchemy_utils import database_exists, create_database
+from sqlalchemy.dialects.postgresql import psycopg2
 from sqlalchemy.orm import sessionmaker
+
+from skate_tricks.schemas.postgres_models import Base
 
 
 class DbSettings(BaseSettings):
@@ -51,6 +55,15 @@ def get_db_session(db_settings: DbSettings = Depends(get_db_settings)) -> DictCu
     engine = create_engine(db_settings.DATABASE_DSN)
     db = sessionmaker(autoflush=False, autocommit=False, bind=engine)()
     try:
+        print("database yielded")
+        Base.metadata.create_all(bind=engine)
         yield db
+    # except psycopg2.exc.OperationalError as operr:
+    #     if not database_exists(db_settings.DATABASE_DSN):
+    #         create_database(db_settings.DATABASE_DSN)
+    #
+    #         print("database created")
+    #     else:
+    #         raise operr
     finally:
         db.close()

--- a/skate_tricks/database_operations.py
+++ b/skate_tricks/database_operations.py
@@ -1,19 +1,19 @@
 import fastapi
 from sqlalchemy.orm import Session
 from pydantic import typing
-from schemas import pydantic_schemas as schemas
-from schemas import postgres_models as models
+from skate_tricks.schemas import pydantic_schemas as json_schemas
+from skate_tricks.schemas import postgres_models as models
 
 
 def get_all_tricks(db: Session) -> typing.List[models.SkateTricks]:
     db_query = (
         db.query(models.SkateTricks)
-        .order_by(models.SkateTricks.fundamental)
-        .order_by(models.SkateTricks.flip)
-        .order_by(models.SkateTricks.board_rotation)
-        .order_by(models.SkateTricks.board_spin)
-        .order_by(models.SkateTricks.body_rotation)
-        .order_by(models.SkateTricks.body_spin)
+        .order_by(models.SkateTricks.fundamental.desc())
+        .order_by(models.SkateTricks.flip.desc())
+        .order_by(models.SkateTricks.board_rotation.desc())
+        .order_by(models.SkateTricks.board_spin.desc())
+        .order_by(models.SkateTricks.body_rotation.desc())
+        .order_by(models.SkateTricks.body_spin.desc())
         .all()
     )
     return db_query
@@ -21,7 +21,7 @@ def get_all_tricks(db: Session) -> typing.List[models.SkateTricks]:
 
 def post_new_trick(
     db: Session,
-    trick: schemas.SkateTricksBase,
+    trick: json_schemas.SkateTricksBase,
     fundamental_tricks: typing.Optional[typing.List[str]],
 ) -> models.SkateTricks:
     db_new_trick = models.SkateTricks(
@@ -56,7 +56,7 @@ def post_new_trick(
 
 def post_variation_trick_fundamentals(
     db: Session, trick_name: str, fundamental_trick_name: str
-) -> schemas.TrickFundamentalsCreate:
+) -> json_schemas.TrickFundamentalsCreate:
     db_trick = (
         db.query(models.SkateTricks)
         .filter(models.SkateTricks.name == trick_name.lower())
@@ -80,7 +80,7 @@ def post_variation_trick_fundamentals(
             detail=f"""The fundamental trick {fundamental_trick_name} is either not fundamental,
             or doesn't exist in the database.""",
         )
-    db_trick_fundamentals = schemas.TrickFundamentalsCreate(
+    db_trick_fundamentals = json_schemas.TrickFundamentalsCreate(
         trick_name=trick_name.lower(),
         fundamental_trick_name=fundamental_trick_name.lower(),
     )

--- a/skate_tricks/database_operations.py
+++ b/skate_tricks/database_operations.py
@@ -22,7 +22,7 @@ def get_all_tricks(db: Session) -> typing.List[models.SkateTricks]:
 def post_new_trick(
     db: Session,
     trick: json_schemas.SkateTricksBase,
-    fundamental_tricks: typing.Optional[typing.List[str]],
+    fundamental_tricks: typing.Optional[typing.List[str]] = None,
 ) -> models.SkateTricks:
     db_new_trick = models.SkateTricks(
         name=trick.name,

--- a/skate_tricks/database_operations.py
+++ b/skate_tricks/database_operations.py
@@ -26,7 +26,7 @@ def post_new_trick(
 ) -> models.SkateTricks:
     db_new_trick = models.SkateTricks(
         name=trick.name,
-        basic=trick.basic,
+        fundamental=trick.fundamental,
         flip=trick.flip,
         board_rotation=trick.board_rotation,
         board_spin=trick.board_spin,

--- a/skate_tricks/run.py
+++ b/skate_tricks/run.py
@@ -1,0 +1,10 @@
+import uvicorn
+
+from skate_tricks.api_endpoints import app
+from skate_tricks.configs.api_config import get_api_settings
+
+if (
+    __name__ == "__main__"
+):  # TODO check/findout user and password for postgres database on VM
+    api_config = get_api_settings()
+    uvicorn.run(app, host="127.0.0.1", port=api_config.API_PORT)

--- a/skate_tricks/schemas/postgres_models.py
+++ b/skate_tricks/schemas/postgres_models.py
@@ -1,13 +1,15 @@
 from sqlalchemy import Column, Integer, Boolean, Enum, Text, Table, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base as base
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
 from skate_tricks.constants.enums import FlipType, RotationDirection, SpinDegrees
 
+Base = declarative_base()
+
 # Associative Tables
 variation_tricks = Table(
     "combo_tricks",
-    base.metadata,
+    Base.metadata,
     Column(
         "trick_id",
         Integer,
@@ -24,7 +26,7 @@ variation_tricks = Table(
 
 
 # Tables
-class SkateTricks(base):
+class SkateTricks(Base):  # type: ignore
     __tablename__ = "skate_tricks"
 
     id = Column(Integer, primary_key=True)
@@ -36,7 +38,7 @@ class SkateTricks(base):
     body_rotation = Column(Enum(RotationDirection), nullable=True)
     body_spin = Column(Enum(SpinDegrees), nullable=True)
 
-    # Relationships
-    combo_of_fundamental = relationship(
-        "SkateTricks", secondary=variation_tricks, back_populates="combo_of_fundamental"
-    )
+    # # Relationships  # TODO fix relationship to work
+    # combo_of_fundamental = relationship(
+    #     "SkateTricks", secondary=variation_tricks, back_populates="combo_of_fundamental"
+    # )

--- a/skate_tricks/schemas/postgres_models.py
+++ b/skate_tricks/schemas/postgres_models.py
@@ -8,7 +8,7 @@ Base = declarative_base()
 
 # Associative Tables
 variation_tricks = Table(
-    "combo_tricks",
+    "variation_tricks",
     Base.metadata,
     Column(
         "trick_id",
@@ -38,7 +38,11 @@ class SkateTricks(Base):  # type: ignore
     body_rotation = Column(Enum(RotationDirection), nullable=True)
     body_spin = Column(Enum(SpinDegrees), nullable=True)
 
-    # # Relationships  # TODO fix relationship to work
-    # combo_of_fundamental = relationship(
-    #     "SkateTricks", secondary=variation_tricks, back_populates="combo_of_fundamental"
-    # )
+    # Relationships
+    fundamental_tricks = relationship(
+        "SkateTricks",
+        secondary=variation_tricks,
+        primaryjoin=variation_tricks.c.trick_id == id,
+        secondaryjoin=variation_tricks.c.fundamental_trick_id == id,
+        backref="variation_trick",
+    )

--- a/skate_tricks/schemas/pydantic_schemas.py
+++ b/skate_tricks/schemas/pydantic_schemas.py
@@ -6,7 +6,7 @@ from skate_tricks.constants.enums import RotationDirection, FlipType, SpinDegree
 
 class SkateTricksBase(BaseModel):
     name: str
-    basic: bool
+    fundamental: bool
     flip: FlipType
     board_rotation: Optional[RotationDirection]
     board_spin: Optional[SpinDegrees]

--- a/tests/database_operations_test.py
+++ b/tests/database_operations_test.py
@@ -1,12 +1,25 @@
 from alchemy_mock.mocking import UnifiedAlchemyMagicMock
 
-from skate_tricks.database_operations import get_all_tricks
+from skate_tricks.database_operations import get_all_tricks, post_new_trick
 from skate_tricks.schemas import postgres_models as models
+from skate_tricks.schemas.pydantic_schemas import SkateTricksBase
 
 session = UnifiedAlchemyMagicMock()
 
-session.add(models.SkateTricks(name="ollie", fundamental=True, flip="ollie"))
-session.add(models.SkateTricks(name="kickflip", fundamental=True, flip="kickflip"))
+session.add(
+    models.SkateTricks(
+        name="ollie", fundamental=True, flip="ollie", body_rotation=None, body_spin=None
+    )
+)
+session.add(
+    models.SkateTricks(
+        name="kickflip",
+        fundamental=True,
+        flip="kickflip",
+        body_rotation=None,
+        body_spin=None,
+    )
+)
 session.add(
     models.SkateTricks(
         name="bs 180",
@@ -34,7 +47,15 @@ session.add(
         body_spin="180",
     )
 )
-session.add(models.SkateTricks(name="heelflip", fundamental=True, flip="heelflip"))
+session.add(
+    models.SkateTricks(
+        name="heelflip",
+        fundamental=True,
+        flip="heelflip",
+        body_rotation=None,
+        body_spin=None,
+    )
+)
 session.add(
     models.SkateTricks(
         name="tre flip",
@@ -51,5 +72,35 @@ def test_get_all_tricks() -> None:
     assert query is not None
 
 
-def test_get_all_tricks_order() -> None:
+def test_get_all_tricks_order() -> None:  # I think this fails as filters don't work with the mocker
     pass
+
+
+def test_create_skate_trick_without_fundamental_tricks() -> None:
+    new_trick = post_new_trick(
+        db=session,
+        trick=SkateTricksBase(
+            name="fs 180",
+            fundamental=True,
+            flip="ollie",
+            body_roation="fs",
+            body_spin="180",
+        ),
+        fundamental_tricks=None,
+    )
+    assert isinstance(new_trick, models.SkateTricks)
+
+
+def test_create_skate_trick_with_fundamental_tricks() -> None:  # I think this fails as filters don't work with the mocker
+    new_trick = post_new_trick(
+        db=session,
+        trick=SkateTricksBase(
+            name="fs flip",
+            fundamental=False,
+            flip="kickflip",
+            body_roation="fs",
+            body_spin="180",
+        ),
+        fundamental_tricks=["kickflip", "fs 180"],
+    )
+    assert isinstance(new_trick, models.SkateTricks)

--- a/tests/database_operations_test.py
+++ b/tests/database_operations_test.py
@@ -1,0 +1,55 @@
+from alchemy_mock.mocking import UnifiedAlchemyMagicMock
+
+from skate_tricks.database_operations import get_all_tricks
+from skate_tricks.schemas import postgres_models as models
+
+session = UnifiedAlchemyMagicMock()
+
+session.add(models.SkateTricks(name="ollie", fundamental=True, flip="ollie"))
+session.add(models.SkateTricks(name="kickflip", fundamental=True, flip="kickflip"))
+session.add(
+    models.SkateTricks(
+        name="bs 180",
+        fundamental=True,
+        flip="ollie",
+        body_rotation="bs",
+        body_spin="180",
+    )
+)
+session.add(
+    models.SkateTricks(
+        name="bs flip",
+        fundamental=False,
+        flip="kickflip",
+        body_rotation="bs",
+        body_spin="180",
+    )
+)
+session.add(
+    models.SkateTricks(
+        name="varial flip",
+        fundamental=False,
+        flip="kickflip",
+        board_rotation="bs",
+        body_spin="180",
+    )
+)
+session.add(models.SkateTricks(name="heelflip", fundamental=True, flip="heelflip"))
+session.add(
+    models.SkateTricks(
+        name="tre flip",
+        fundamental=False,
+        flip="kickflip",
+        board_rotation="bs",
+        board_spin="360",
+    )
+)
+
+
+def test_get_all_tricks() -> None:
+    query = get_all_tricks(db=session)
+    assert query is not None
+
+
+def test_get_all_tricks_order() -> None:
+    pass


### PR DESCRIPTION
In this branch I created the fastapi api for the tricks database this meant adding the following files:
-api_endpoints.py
-api_config.py
-run.py
alongside database_operations_test.py which needs to be overhauled by using a test database, as the package 'alchemy-mock'
that I use here doesn't work completely, e.g. not ordering queries made.

a big change was the definition for the relationship between tricks and the fundamental tricks that make them up by adding a 
'primary_join' and 'secondary_join' parameters

other small changes include refactoring basic_trick => fundamental_trick, when using pydantic_schemas importing them as json_schemas to save incorrect variable usage, from 'base = declarative_base' to 'Base = declarative_base()' and combo_of_fundamental => fundamental_tricks